### PR TITLE
Custom Validator::replacer

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -15,8 +15,8 @@ class ServiceProvider extends BaseServiceProvider
     {
         Validator::extend('pwned', Pwned::class);
 
-        Validator::replacer('count', function ($message, $attribute, $rule, $parameters) {
-            return str_replace(':count', $attribute.' - '.$rule.' - '.implode(',', $parameters), $message);
+        Validator::replacer('pwned', function ($message, $attribute, $rule, $parameters) {
+            return str_replace(':min', array_shift($parameters) ?? 1, $message);
         });
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -14,6 +14,10 @@ class ServiceProvider extends BaseServiceProvider
     public function boot()
     {
         Validator::extend('pwned', Pwned::class);
+
+        Validator::replacer('count', function ($message, $attribute, $rule, $parameters) {
+            return str_replace(':count', $attribute.' - '.$rule.' - '.implode(',', $parameters), $message);
+        });
     }
 
     /**


### PR DESCRIPTION
Nothing big, just a simple str_replace on the validation error message to show the minimum amount of times set when using `pwned`.

Example:
```
Your password is insufficiently secure as it has been found at least :min times in known password breaches, please chose a new one
```
![](https://user-images.githubusercontent.com/14265751/38718421-049f0db6-3ebb-11e8-82b7-6f2a6d830e51.png)


It'd be cooler if you could pass along the exact count, but as far as I know, you can't pass that by any logical way. The only (very bad) way I can think of would be session flashing/storing it, but that is a very bad way.