### PR TITLE
Updated cache duration to laravel 5.8 changes

### DIFF
--- a/src/Pwned.php
+++ b/src/Pwned.php
@@ -52,7 +52,7 @@ class Pwned implements Rule
     private function query($prefix)
     {
         // Cache results for a week, to avoid constant API calls for identical prefixes
-        return Cache::remember('pwned:'.$prefix, 10080, function () use ($prefix) {
+        return Cache::remember('pwned:'.$prefix, now()->addWeek(), function () use ($prefix) {
             $curl = curl_init('https://api.pwnedpasswords.com/range/'.$prefix);
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
             $results = curl_exec($curl);


### PR DESCRIPTION
In laravel 5.8 the cache duration has been changed to use seconds instead of minutes. Head over to [https://laravel.com/docs/5.8/upgrade#cache-ttl-in-seconds](https://laravel.com/docs/5.8/upgrade#cache-ttl-in-seconds) for more information.