### PR TITLE
Add Laravel 10 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=7.2",
         "ext-curl": "*",
-        "illuminate/support": "^5.5||^6.0||^7.0||^8.0|^9.0"
+        "illuminate/support": "^5.5||^6.0||^7.0||^8.0|^9.0|^10.0"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
This change updates the required `illuminate/support` dependency version to allow for compatibility with Laravel 10.x projects.